### PR TITLE
Added an alternate (newer) version of package linq.js

### DIFF
--- a/repo_data/linqjs.json
+++ b/repo_data/linqjs.json
@@ -14,7 +14,7 @@
       "version": "3.0.3-Beta4",
       "key": "5d10dbc5-3ce1-4c36-b344-8a98e1bc1e35",
       "dependencies": [],
-      "url": "https://github.com/bdb-opensource/DefinitelyTyped/raw/linqjs-v3/linq/linq.d.ts",
+      "url": "https://github.com/borisyankov/DefinitelyTyped/raw/master/linq/linq.3.0.3-Beta4.d.ts",
       "author": "neuecc",
       "author_url": "http://www.codeplex.com/site/users/view/neuecc"
     }


### PR DESCRIPTION
There is a new version of this library at http://linqjs.codeplex.com/releases/view/91395, with TS definition files. Since DefinitelyTyped can only have one version at a time, I forked DefinitelyTyped and added a version entry here to the forked d.ts files.
