### PR TITLE
Updated to 0.4.x version

### DIFF
--- a/deploy/tsd.js
+++ b/deploy/tsd.js
@@ -839,7 +839,7 @@ var Command;
             this._withRepoIndex = false;
         }
         InstallCommand.prototype.accept = function (args) {
-            return (args[2] == this.shortcut || args[2] == this.shortcut + '*');
+            return (args[2] == this.shortcut || args[2] == this.shortcut + '*' || args[2] == this.shortcut + '-all');
         };
         InstallCommand.prototype.print = function (lib) {
             System.Console.write(lib.name + ' - ' + lib.description + '[');
@@ -1017,6 +1017,8 @@ var Command;
         };
         InstallCommand.prototype.exec = function (args) {
             if(args[2].indexOf('*') != -1) {
+                this._withDep = true;
+            } else if(args[2] == this.shortcut + '-all') {
                 this._withDep = true;
             }
             if(!args[3]) {


### PR DESCRIPTION
---

This version is not under `npm` yet. To test this version you will need to clone the `develop-0.4.x` branch

```
git clone -b develop-0.4.x git://github.com/Diullei/tsd.git
```

go to `tsd` directory and install `tsd`

```
npm i -g tsd
```

---
#10

Now it is possible to install different file versions.
Example:

```
 tsd install linqjs@3.0.3-beta4
```

> This command will install the `3.0.3-beta4` version.

```
 tsd install linqjs@2.2
```

> This command will install the `2.2` version.
> OBS `tsd install linqjs` will install the last `linqjs` version
#13

Now is possible to use `install-all` to have the same behaviour as the command `install*`
#14

This version will keep all installed dependencies on file `tsd-config.json`. If you have a `tsd-config.json` file you can use `tsd install` command to install the dependencies defined in this file.
