### PR TITLE
Add tips to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ List *everything*:
 		
 	$ tsd query *
 
+Tips: If you are using Linux or Mac OS X, use `$ tsd query "*"` command.
+
 Get some info about 'jquery':
 		
 	$ tsd query jquery --info --history --resolve


### PR DESCRIPTION
in UNIX OS's shell (e.g. bash, zsh) are expand a wild card automatically.
I had add a tips to README.md.
If my english is not good, please fix it ;)
