### PR TITLE
Allow saving bundle without overwriting tsd.json

### DIFF
--- a/src/tsd/API.ts
+++ b/src/tsd/API.ts
@@ -155,8 +155,8 @@ class API {
 				bundles.push(bundle);
 			});
 		}
-		// TODO re-use config var?
-		if (options.saveToConfig && this.context.config.bundle) {
+
+		if ((options.saveToConfig || options.saveBundle) && this.context.config.bundle) {
 			bundles.push(path.resolve(basePath, this.context.config.bundle));
 		}
 

--- a/src/tsd/CLI.ts
+++ b/src/tsd/CLI.ts
@@ -168,6 +168,7 @@ export function getExpose(): Expose {
 				job.options.maxMatches = ctx.getOpt(Opt.max);
 
 				job.options.saveToConfig = ctx.getOpt(Opt.save);
+				job.options.saveBundle = ctx.getOpt(Opt.save);
 				job.options.overwriteFiles = ctx.getOpt(Opt.overwrite);
 				job.options.resolveDependencies = ctx.getOpt(Opt.resolve);
 				job.options.addToBundles = ctx.getOpt(Opt.bundle);

--- a/src/tsd/Options.ts
+++ b/src/tsd/Options.ts
@@ -17,6 +17,7 @@ class Options {
 	resolveDependencies: boolean = false;
 	overwriteFiles: boolean = false;
 	saveToConfig: boolean = false;
+	saveBundle: boolean = false;
 	addToBundles: string[] = [];
 
 	static fromJSON(json: Object): Options {


### PR DESCRIPTION
Required as we use [gulp-tsd](https://github.com/moznion/gulp-tsd) to download typings as part of our build, but with `saveToConfig` set it makes our change detection believe that `tsd.json` has changed. When doing fully specified builds it shouldn't be required to touch `tsd.json`.
