### PR TITLE
Check for the existance of file.def.head before looking inside it

### DIFF
--- a/src/tsd/API.ts
+++ b/src/tsd/API.ts
@@ -262,7 +262,7 @@ class API {
 		return Promise.resolve(list.map((file: DefVersion) => {
 			var ref = file.commit.commitSha;
 			// same? 
-			if (file.def.head !== undefined && file.commit.commitSha === file.def.head.commit.commitSha) {
+			if (file.def.head && file.commit.commitSha === file.def.head.commit.commitSha) {
 				ref = this.core.context.config.ref;
 			}
 			var url = this.core.repo.urls.htmlFile(ref, file.def.path);

--- a/src/tsd/API.ts
+++ b/src/tsd/API.ts
@@ -261,8 +261,8 @@ class API {
 
 		return Promise.resolve(list.map((file: DefVersion) => {
 			var ref = file.commit.commitSha;
-			// same?
-			if (file.commit.commitSha === file.def.head.commit.commitSha) {
+			// same? 
+			if (file.def.head !== undefined && file.commit.commitSha === file.def.head.commit.commitSha) {
 				ref = this.core.context.config.ref;
 			}
 			var url = this.core.repo.urls.htmlFile(ref, file.def.path);

--- a/src/tsd/logic/ContentLoader.ts
+++ b/src/tsd/logic/ContentLoader.ts
@@ -62,7 +62,7 @@ class ContentLoader extends CoreModule {
 		}
 		var ref = file.commit.commitSha;
 		// re-cycle head
-		if (tryHead && file.def.head !== undefined && file.commit.commitSha === file.def.head.commit.commitSha) {
+		if (tryHead && file.def.head && file.commit.commitSha === file.def.head.commit.commitSha) {
 			ref = this.core.context.config.ref;
 		}
 		return this.core.repo.raw.getBinary(ref, file.def.path).then((content: Buffer) => {

--- a/src/tsd/logic/ContentLoader.ts
+++ b/src/tsd/logic/ContentLoader.ts
@@ -62,7 +62,7 @@ class ContentLoader extends CoreModule {
 		}
 		var ref = file.commit.commitSha;
 		// re-cycle head
-		if (tryHead && file.commit.commitSha === file.def.head.commit.commitSha) {
+		if (tryHead && file.def.head !== undefined && file.commit.commitSha === file.def.head.commit.commitSha) {
 			ref = this.core.context.config.ref;
 		}
 		return this.core.repo.raw.getBinary(ref, file.def.path).then((content: Buffer) => {


### PR DESCRIPTION
Files moved between commits will no longer cause issues.
This was noticed when angular-ui-router was moved from angular-ui to its own subdirectory