### PR TITLE
use raw.githubusercontent.com

### DIFF
--- a/src/git/GithubURLs.ts
+++ b/src/git/GithubURLs.ts
@@ -15,7 +15,7 @@ class GithubURLs extends URLManager {
 	private _base: string = 'https://github.com/{owner}/{project}';
 	private _apiBase: string = 'https://api.github.com';
 	private _api: string = 'https://api.github.com/repos/{owner}/{project}';
-	private _raw: string = 'https://raw.github.com/{owner}/{project}';
+	private _raw: string = 'https://raw.githubusercontent.com/{owner}/{project}';
 	private _repo: GithubRepo;
 
 	constructor(repo: GithubRepo) {

--- a/src/spec/git/GithubURLs.ts
+++ b/src/spec/git/GithubURLs.ts
@@ -58,7 +58,7 @@ describe('GithubRepo / GithubURLs', () => {
 		it('should return replaced urls', () => {
 			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar'}, 'baz', gitTest.opts).urls;
 			var api = 'https://api.github.com/repos/foo/bar';
-			var raw = 'https://raw.github.com/foo/bar';
+			var raw = 'https://raw.githubusercontent.com/foo/bar';
 			var base = 'https://github.com/foo/bar';
 			var rawFile = raw + '/2ece23298f06d9fb45772fdb1d38086918c80f44/sub/folder/file.txt';
 			assert.strictEqual(urls.api(), api, 'api');
@@ -71,7 +71,7 @@ describe('GithubRepo / GithubURLs', () => {
 			repoConfig.repoOwner = 'correctOwner';
 			repoConfig.repoProject = 'correctProject';
 			var api = 'https://api.github.com/repos/correctOwner/correctProject';
-			var raw = 'https://raw.github.com/correctOwner/correctProject';
+			var raw = 'https://raw.githubusercontent.com/correctOwner/correctProject';
 			var base = 'https://github.com/correctOwner/correctProject';
 			assert.strictEqual(urls.api(), api, 'api');
 			assert.strictEqual(urls.base(), base, 'base');


### PR DESCRIPTION
Fixes #139 

Note, I still have some test failures, so this is not ready to merge. I am not sure why:

```
-> reporting 17 failures

1:    API search query "async-info"

      Error: no result body: https://raw.githubusercontent.com/borisyankov/DefinitelyTyped/master/async/async.d.ts -> 2271dafd800fb0437db21c63217a3ba8407b7c55
         at /Users/alexeagle/Projects/tsd/src/http/CacheStreamLoader.ts:124:12
         at Promise.b (domain.js:183:18)
...
```