### PR TITLE
Trim jsonString to prevent possible special character issues in beginning / end of files

### DIFF
--- a/src/xm/lib/JSONStabilizer.ts
+++ b/src/xm/lib/JSONStabilizer.ts
@@ -42,7 +42,7 @@ class JSONStabilizer {
 	}
 
 	parseString(jsonString: string): Object {
-		var object = JSON.parse(jsonString);
+		var object = JSON.parse(jsonString.trim());
 		this.style = new CodeStyle();
 		this.sniff(jsonString);
 		this.snapshot(object);


### PR DESCRIPTION
While working in Visual Studio 2015 with Gulp and TSD, I encountered an issue with JSONStabilizer.parseString() method when parsing tsd.json. The exact error is "SyntaxError: Unexpected token", which is a native error from the JSON.parse() method.

Upon closer inspection, there is some sort of special non-word character in the beginning of the tsd.json string. It's not visible when editing the file, and there doesn't seem to be any way to get rid of it, so I'm assuming it's some sort of quirk with fs.readFile() and Windows / VS2015 encoding. Adding a .trim() to the jsonString will remove any possible special characters at the beginning or end of the file and prevent any error in the future.