### PR TITLE
Remove unused `prefix` constructor parameter in GithubLoader

### DIFF
--- a/src/git/loader/GithubAPI.ts
+++ b/src/git/loader/GithubAPI.ts
@@ -28,7 +28,7 @@ class GithubAPI extends GithubLoader {
 	private apiVersion: string = '3.0.0';
 
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
-		super(urls, options, shared, storeDir, 'github-api', 'GithubAPI');
+		super(urls, options, shared, storeDir, 'GithubAPI');
 
 		this.formatVersion = '1.0';
 

--- a/src/git/loader/GithubLoader.ts
+++ b/src/git/loader/GithubLoader.ts
@@ -32,7 +32,7 @@ class GithubLoader {
 
 	headers = {};
 
-	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string, prefix: string, label: string) {
+	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string, label: string) {
 		assertVar(urls, GithubURLs, 'urls');
 		assertVar(options, JSONPointer, 'options');
 		assertVar(shared, JSONPointer, 'shared');

--- a/src/git/loader/GithubRaw.ts
+++ b/src/git/loader/GithubRaw.ts
@@ -21,7 +21,7 @@ import GithubRateInfo = require('../model/GithubRateInfo');
 class GithubRaw extends GithubLoader {
 
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
-		super(urls, options, shared, storeDir, 'github-raw', 'GithubRaw');
+		super(urls, options, shared, storeDir, 'GithubRaw');
 
 		this.formatVersion = '1.0';
 


### PR DESCRIPTION
Noticed that the `prefix` constructor parameter is unused in the
`GithubLoader` base class.