### PR TITLE
Changed to new command for installing from tsd.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ tsd query jquery.*
 $ tsd query "jquery.*"
 
 #install all definitions from tsd.json
-$ tsd install
+$ tsd reinstall
 ````
 
 ### Commands


### PR DESCRIPTION
Small documentation update, change from tsd install to tsd reinstall for installation from tsd.json file.