### PR TITLE
Eliminate implicit property ordering for cache key

### DIFF
--- a/src/git/GithubRepo.ts
+++ b/src/git/GithubRepo.ts
@@ -33,14 +33,11 @@ class GithubRepo {
 		this.config = config;
 		this.urls = new GithubURLs(this);
 
-		this.storeDir = path.join(storeDir.replace(/[\\\/]+$/, ''), this.getCacheKey());
+		var cacheKey = this.config.repoOwner + '-' + this.config.repoProject;
+		this.storeDir = path.join(storeDir.replace(/[\\\/]+$/, ''), cacheKey);
 
 		this.api = new GithubAPI(this.urls, opts.getChild('git/api'), opts, this.storeDir);
 		this.raw = new GithubRaw(this.urls, opts.getChild('git/raw'), opts, this.storeDir);
-	}
-
-	getCacheKey(): string {
-		return this.config.repoOwner + '-' + this.config.repoProject;
 	}
 
 	toString(): string {

--- a/src/git/loader/GithubAPI.ts
+++ b/src/git/loader/GithubAPI.ts
@@ -25,14 +25,18 @@ import GithubRateInfo = require('../model/GithubRateInfo');
 class GithubAPI extends GithubLoader {
 
 	// github's version
-	private apiVersion: string = '3.0.0';
+	private static API_VERSION: string = '3.0.0';
+	private static FORMAT_VERSION: string = '1.0';
+	private static CACHE_KEY: string = 'git-api-v' + GithubAPI.API_VERSION + '-fmt' + GithubAPI.FORMAT_VERSION;
+
+	static NAME: string = 'GithubAPI';
 
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
-		super(urls, options, shared, storeDir, 'GithubAPI');
+		super(urls, options, shared, storeDir, GithubAPI.NAME);
 
-		this.formatVersion = '1.0';
+		this.formatVersion = GithubAPI.FORMAT_VERSION;
 
-		this._initGithubLoader();
+		this._initGithubLoader(GithubAPI.CACHE_KEY);
 	}
 
 	getBranches(): Promise<any> {
@@ -121,10 +125,6 @@ class GithubAPI extends GithubLoader {
 				}
 			});
 		});
-	}
-
-	getCacheKey(): string {
-		return 'git-api-v' + this.apiVersion + '-fmt' + this.formatVersion;
 	}
 }
 

--- a/src/git/loader/GithubLoader.ts
+++ b/src/git/loader/GithubLoader.ts
@@ -45,14 +45,14 @@ class GithubLoader {
 		this.label = label;
 	}
 
-	_initGithubLoader(): void {
+	_initGithubLoader(cacheKey: string): void {
 		var cache = new CacheOpts();
 		cache.allowClean = this.options.getBoolean('allowClean', cache.allowClean);
 		cache.cleanInterval = this.options.getDurationSecs('cacheCleanInterval', cache.cleanInterval / 1000) * 1000;
 		cache.splitDirLevel = this.options.getNumber('splitDirLevel', cache.splitDirLevel);
 		cache.splitDirChunk = this.options.getNumber('splitDirChunk', cache.splitDirChunk);
 		cache.jobTimeout = this.options.getDurationSecs('jobTimeout', cache.jobTimeout / 1000) * 1000;
-		cache.storeDir = path.join(this.storeDir, this.getCacheKey());
+		cache.storeDir = path.join(this.storeDir, cacheKey);
 
 		var opts: HTTPOpts = {
 			cache: cache,
@@ -71,11 +71,6 @@ class GithubLoader {
 		this.cache = new HTTPCache(opts);
 		// required to have some header
 		this.headers['user-agent'] = this.label + '-v' + this.formatVersion;
-	}
-
-	getCacheKey(): string {
-		// override
-		return 'loader';
 	}
 
 	copyHeadersTo(target: any, source?: any) {

--- a/src/git/loader/GithubRaw.ts
+++ b/src/git/loader/GithubRaw.ts
@@ -19,13 +19,16 @@ import GithubRateInfo = require('../model/GithubRateInfo');
  GithubRaw: get files from raw.github.com and cache on disk
  */
 class GithubRaw extends GithubLoader {
+	private static API_VERSION: string = '3.0.0';
+	private static FORMAT_VERSION: string = '1.0';
+	private static CACHE_KEY = 'git-raw-fmt' + GithubRaw.FORMAT_VERSION;
 
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
 		super(urls, options, shared, storeDir, 'GithubRaw');
 
-		this.formatVersion = '1.0';
+		this.formatVersion = GithubRaw.FORMAT_VERSION;
 
-		this._initGithubLoader();
+		this._initGithubLoader(GithubRaw.CACHE_KEY);
 	}
 
 	getText(ref: string, filePath: string): Promise<string> {
@@ -67,10 +70,6 @@ class GithubRaw extends GithubLoader {
 		return this.cache.getObject(request).then((object: CacheObject) => {
 			return object.body;
 		});
-	}
-
-	getCacheKey(): string {
-		return 'git-raw-fmt' + this.formatVersion;
 	}
 }
 


### PR DESCRIPTION
There is an implicit ordering of setting properties and the invocation
of base class methods in order for GithubLoader to properly initialize
itself with the appropriate cache key.  This change removes that
implicit ordering and passes, explicitly, the cache key string value to
the `GithubLoader::_initGithubLoader` method.

Note that I am working towards taking care of #186, but in order to do so, I need to make some incremental changes along the way.