### PR TITLE
Elminate implicit property ordering for format version

### DIFF
--- a/src/git/loader/GithubAPI.ts
+++ b/src/git/loader/GithubAPI.ts
@@ -33,10 +33,7 @@ class GithubAPI extends GithubLoader {
 
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
 		super(urls, options, shared, storeDir, GithubAPI.NAME);
-
-		this.formatVersion = GithubAPI.FORMAT_VERSION;
-
-		this._initGithubLoader(GithubAPI.CACHE_KEY);
+		this._initGithubLoader(GithubAPI.CACHE_KEY, GithubAPI.FORMAT_VERSION);
 	}
 
 	getBranches(): Promise<any> {

--- a/src/git/loader/GithubLoader.ts
+++ b/src/git/loader/GithubLoader.ts
@@ -45,7 +45,7 @@ class GithubLoader {
 		this.label = label;
 	}
 
-	_initGithubLoader(cacheKey: string): void {
+	_initGithubLoader(cacheKey: string, formatVersion: string): void {
 		var cache = new CacheOpts();
 		cache.allowClean = this.options.getBoolean('allowClean', cache.allowClean);
 		cache.cleanInterval = this.options.getDurationSecs('cacheCleanInterval', cache.cleanInterval / 1000) * 1000;
@@ -70,7 +70,7 @@ class GithubLoader {
 
 		this.cache = new HTTPCache(opts);
 		// required to have some header
-		this.headers['user-agent'] = this.label + '-v' + this.formatVersion;
+		this.headers['user-agent'] = this.label + '-v' + formatVersion;
 	}
 
 	copyHeadersTo(target: any, source?: any) {

--- a/src/git/loader/GithubRaw.ts
+++ b/src/git/loader/GithubRaw.ts
@@ -25,10 +25,7 @@ class GithubRaw extends GithubLoader {
 
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
 		super(urls, options, shared, storeDir, 'GithubRaw');
-
-		this.formatVersion = GithubRaw.FORMAT_VERSION;
-
-		this._initGithubLoader(GithubRaw.CACHE_KEY);
+		this._initGithubLoader(GithubRaw.CACHE_KEY, GithubRaw.FORMAT_VERSION);
 	}
 
 	getText(ref: string, filePath: string): Promise<string> {


### PR DESCRIPTION
There is an implicit ordering for setting GithubLoader.formatVersion in
the derived class's constructor before finishing initialization via the
`GithubLoader::_initGithubLoader()` method.  This change removes that
implicit ordering and is an incremental step towards eliminating
`GithubLoader::_initGithubLoader()`, which will occur in a future
commit.