### PR TITLE
Move GithubLoader._initGithubLoader logic into GithubLoader constructor

### DIFF
--- a/src/git/loader/GithubAPI.ts
+++ b/src/git/loader/GithubAPI.ts
@@ -23,8 +23,6 @@ import GithubRateInfo = require('../model/GithubRateInfo');
 
 // TODO add OAuth support (here or in HTTPCache)
 class GithubAPI extends GithubLoader {
-
-	// github's version
 	private static API_VERSION: string = '3.0.0';
 	private static FORMAT_VERSION: string = '1.0';
 	private static CACHE_KEY: string = 'git-api-v' + GithubAPI.API_VERSION + '-fmt' + GithubAPI.FORMAT_VERSION;
@@ -32,8 +30,7 @@ class GithubAPI extends GithubLoader {
 	static NAME: string = 'GithubAPI';
 
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
-		super(urls, options, shared, storeDir, GithubAPI.NAME);
-		this._initGithubLoader(GithubAPI.CACHE_KEY, GithubAPI.FORMAT_VERSION);
+		super(urls, options, shared, storeDir, GithubAPI.CACHE_KEY, GithubAPI.NAME, GithubAPI.FORMAT_VERSION);
 	}
 
 	getBranches(): Promise<any> {

--- a/src/git/loader/GithubLoader.ts
+++ b/src/git/loader/GithubLoader.ts
@@ -20,48 +20,46 @@ import GithubRateInfo = require('../model/GithubRateInfo');
 class GithubLoader {
 
 	urls: GithubURLs;
-
-	cache: HTTPCache;
 	options: JSONPointer;
-	shared: JSONPointer;
+	cache: HTTPCache;
+	headers: {[index: string]: string} = {};
 
-	storeDir: string;
+	constructor(
+		urls: GithubURLs,
+		options: JSONPointer,
+		shared: JSONPointer,
+		storeDir: string,
+		cacheKey: string,
+		label: string,
+		formatVersion: string) {
 
-	label: string = 'github-loader';
-	formatVersion: string = '0.0.0';
-
-	headers = {};
-
-	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string, label: string) {
 		assertVar(urls, GithubURLs, 'urls');
 		assertVar(options, JSONPointer, 'options');
 		assertVar(shared, JSONPointer, 'shared');
 		assertVar(storeDir, 'string', 'storeDir');
+		assertVar(cacheKey, 'string', 'cacheKey');
+		assertVar(label, 'string', 'label');
+		assertVar(formatVersion, 'string', 'formatVersion');
 
 		this.urls = urls;
 		this.options = options;
-		this.shared = shared;
-		this.storeDir = storeDir;
-		this.label = label;
-	}
 
-	_initGithubLoader(cacheKey: string, formatVersion: string): void {
 		var cache = new CacheOpts();
 		cache.allowClean = this.options.getBoolean('allowClean', cache.allowClean);
 		cache.cleanInterval = this.options.getDurationSecs('cacheCleanInterval', cache.cleanInterval / 1000) * 1000;
 		cache.splitDirLevel = this.options.getNumber('splitDirLevel', cache.splitDirLevel);
 		cache.splitDirChunk = this.options.getNumber('splitDirChunk', cache.splitDirChunk);
 		cache.jobTimeout = this.options.getDurationSecs('jobTimeout', cache.jobTimeout / 1000) * 1000;
-		cache.storeDir = path.join(this.storeDir, cacheKey);
+		cache.storeDir = path.join(storeDir, cacheKey);
 
 		var opts: HTTPOpts = {
 			cache: cache,
-			concurrent: this.shared.getNumber('concurrent', 20),
-			oath: this.shared.getString('oath', null),
-			strictSSL: this.shared.getBoolean('strictSSL', true)
+			concurrent: shared.getNumber('concurrent', 20),
+			oath: shared.getString('oath', null),
+			strictSSL: shared.getBoolean('strictSSL', true)
 		};
 
-		opts.proxy = (this.shared.getString('proxy')
+		opts.proxy = (shared.getString('proxy')
 			|| process.env.HTTPS_PROXY
 			|| process.env.https_proxy
 			|| process.env.HTTP_PROXY
@@ -70,7 +68,7 @@ class GithubLoader {
 
 		this.cache = new HTTPCache(opts);
 		// required to have some header
-		this.headers['user-agent'] = this.label + '-v' + formatVersion;
+		this.headers['user-agent'] = label + '-v' + formatVersion;
 	}
 
 	copyHeadersTo(target: any, source?: any) {
@@ -81,7 +79,6 @@ class GithubLoader {
 	}
 
 	set verbose(verbose: boolean) {
-
 	}
 }
 

--- a/src/git/loader/GithubRaw.ts
+++ b/src/git/loader/GithubRaw.ts
@@ -23,9 +23,10 @@ class GithubRaw extends GithubLoader {
 	private static FORMAT_VERSION: string = '1.0';
 	private static CACHE_KEY = 'git-raw-fmt' + GithubRaw.FORMAT_VERSION;
 
+	static NAME: string = 'GithubRaw';
+
 	constructor(urls: GithubURLs, options: JSONPointer, shared: JSONPointer, storeDir: string) {
-		super(urls, options, shared, storeDir, 'GithubRaw');
-		this._initGithubLoader(GithubRaw.CACHE_KEY, GithubRaw.FORMAT_VERSION);
+		super(urls, options, shared, storeDir, GithubRaw.CACHE_KEY, GithubRaw.NAME, GithubRaw.FORMAT_VERSION);
 	}
 
 	getText(ref: string, filePath: string): Promise<string> {


### PR DESCRIPTION
`GithubLoader::_initGithubLoader()` existed to defer initialization so
that the derived class's constructor could set properties that were
needed. Now that the values needed for initialization can be directly
passed to `super()`, the initialization of GithubLoader can occur
completely in the constructor. Also, some public members were removed
since they are not accessed externally and were only needed for
`_initGithubLoader()`.