### PR TITLE
[Feature] Support for enterprise Github repository

### DIFF
--- a/src/getContent.ts
+++ b/src/getContent.ts
@@ -71,11 +71,12 @@ function getContent(options): Promise<any> {
 		var ret: any = {
 			repo: api.context.config.repo,
 			ref: api.context.config.ref,
+			githubHost: api.context.config.githubHost,
 			count: content.length,
 			time: new Date().toISOString()
 		};
 		ret.urls = {
-			def: 'https://github.com/' + ret.repo + '/blob/' + ret.ref + '/{path}'
+			def: 'https://' + ret.githubHost + '/' + ret.repo + '/blob/' + ret.ref + '/{path}'
 		};
 		ret.content = content;
 		return ret;

--- a/src/git/GithubRepoConfig.ts
+++ b/src/git/GithubRepoConfig.ts
@@ -1,6 +1,7 @@
 /// <reference path="./_ref.d.ts" />
 
 interface GithubRepoConfig {
+	githubHost: string;
 	repoOwner: string;
 	repoProject: string;
 }

--- a/src/git/GithubURLs.ts
+++ b/src/git/GithubURLs.ts
@@ -16,6 +16,11 @@ class GithubURLs extends URLManager {
 	private _apiBase: string = 'https://api.github.com';
 	private _api: string = 'https://api.github.com/repos/{owner}/{project}';
 	private _raw: string = 'https://raw.githubusercontent.com/{owner}/{project}';
+
+	private _enterpriseBase: string = 'https://{githubHost}/{owner}/{project}';
+	private _enterpriseApiBase: string = 'https://{githubHost}/api/v3';
+	private _enterpriseApi: string = 'https://{githubHost}/api/v3/repos/{owner}/{project}';
+	private _enterpriseRaw: string = 'https://{githubHost}/{owner}/{project}/raw';
 	private _repo: GithubRepo;
 
 	constructor(repo: GithubRepo) {
@@ -23,26 +28,38 @@ class GithubURLs extends URLManager {
 		assertVar(repo, 'object', 'repo');
 
 		this._repo = repo;
+		var base: string = this._base;
+		var raw: string = this._raw;
+		var api: string = this._api;
+		var apiBase: string = this._apiBase;
+		if (this._repo.config.githubHost !== 'github.com') {
+			// We are working with an enterprise github
+			base = this._enterpriseBase;
+			raw = this._enterpriseRaw;
+			api = this._enterpriseApi;
+			apiBase = this._enterpriseApiBase;
+		}
 		// externalise later
-		this.addTemplate('base', this._base);
+		this.addTemplate('base', base);
 
-		this.addTemplate('raw', this._raw);
-		this.addTemplate('rawFile', this._raw + '/{+ref}/{+path}');
+		this.addTemplate('raw', raw);
+		this.addTemplate('rawFile', raw + '/{+ref}/{+path}');
 
-		this.addTemplate('htmlFile', this._base + '/blob/{ref}/{+path}');
+		this.addTemplate('htmlFile', base + '/blob/{ref}/{+path}');
 
-		this.addTemplate('api', this._api);
-		this.addTemplate('apiTree', this._api + '/git/trees/{tree}?recursive={recursive}');
-		this.addTemplate('apiBranch', this._api + '/branches/{branch}');
-		this.addTemplate('apiBranches', this._api + '/branches');
-		this.addTemplate('apiCommit', this._api + '/commits/{commit}');
-		this.addTemplate('apiPathCommits', this._api + '/commits?path={path}');
-		this.addTemplate('apiBlob', this._api + '/git/blobs/{blob}');
-		this.addTemplate('rateLimit', this._apiBase + '/rate_limit');
+		this.addTemplate('api', api);
+		this.addTemplate('apiTree', api + '/git/trees/{tree}?recursive={recursive}');
+		this.addTemplate('apiBranch', api + '/branches/{branch}');
+		this.addTemplate('apiBranches', api + '/branches');
+		this.addTemplate('apiCommit', api + '/commits/{commit}');
+		this.addTemplate('apiPathCommits', api + '/commits?path={path}');
+		this.addTemplate('apiBlob', api + '/git/blobs/{blob}');
+		this.addTemplate('rateLimit', apiBase + '/rate_limit');
 	}
 
 	getURL(id: string, vars?: any): string {
 		this.setVars({
+			githubHost: this._repo.config.githubHost,
 			owner: this._repo.config.repoOwner,
 			project: this._repo.config.repoProject
 		});

--- a/src/spec/git/GithubURLs.ts
+++ b/src/spec/git/GithubURLs.ts
@@ -36,11 +36,11 @@ describe('GithubRepo / GithubURLs', () => {
 		});
 		it('should throw on bad params', () => {
 			assert.throws(() => {
-				repo = new GithubRepo({repoOwner: null, repoProject: null}, null, null);
+				repo = new GithubRepo({repoOwner: null, repoProject: null, githubHost: null}, null, null);
 			});
 		});
 		it('should be constructor', () => {
-			repo = new GithubRepo({repoOwner: 'foo', repoProject: 'bar'}, 'baz', gitTest.opts);
+			repo = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'}, 'baz', gitTest.opts);
 			urls = repo.urls;
 			assert.ok(urls, 'instance');
 		});
@@ -56,7 +56,7 @@ describe('GithubRepo / GithubURLs', () => {
 			});
 		});
 		it('should return replaced urls', () => {
-			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar'}, 'baz', gitTest.opts).urls;
+			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'}, 'baz', gitTest.opts).urls;
 			var api = 'https://api.github.com/repos/foo/bar';
 			var raw = 'https://raw.githubusercontent.com/foo/bar';
 			var base = 'https://github.com/foo/bar';
@@ -66,7 +66,7 @@ describe('GithubRepo / GithubURLs', () => {
 			assert.strictEqual(urls.rawFile('2ece23298f06d9fb45772fdb1d38086918c80f44', 'sub/folder/file.txt'), rawFile, 'rawFile');
 		});
 		it('should return correctly replaced urls if repoConfig is modified after repo creation', () => {
-			var repoConfig = {repoOwner: 'foo', repoProject: 'bar'};
+			var repoConfig = {repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'};
 			urls = new GithubRepo(repoConfig, 'baz', gitTest.opts).urls;
 			repoConfig.repoOwner = 'correctOwner';
 			repoConfig.repoProject = 'correctProject';
@@ -77,9 +77,19 @@ describe('GithubRepo / GithubURLs', () => {
 			assert.strictEqual(urls.base(), base, 'base');
 		});
 		it('should return no trailing slash', () => {
-			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar'}, 'baz', gitTest.opts).urls;
+			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'}, 'baz', gitTest.opts).urls;
 			assert.notMatch(urls.apiBranches(), /\/$/, 'apiBranches');
 			assert.notMatch(urls.apiBranch('abc'), /\/$/, 'apiBranch');
+		});
+		it('should handle enterprise github urls', () => {
+			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.mycompany.com'}, 'baz', gitTest.opts).urls;
+			var api = 'https://github.mycompany.com/api/v3/repos/foo/bar';
+			var raw = 'https://github.mycompany.com/foo/bar/raw';
+			var base = 'https://github.mycompany.com/foo/bar';
+			var rawFile = raw + '/2ece23298f06d9fb45772fdb1d38086918c80f44/sub/folder/file.txt';
+			assert.strictEqual(urls.api(), api, 'api');
+			assert.strictEqual(urls.base(), base, 'base');
+			assert.strictEqual(urls.rawFile('2ece23298f06d9fb45772fdb1d38086918c80f44', 'sub/folder/file.txt'), rawFile, 'rawFile');
 		});
 	});
 });

--- a/src/tsd/context/Config.ts
+++ b/src/tsd/context/Config.ts
@@ -41,6 +41,7 @@ class Config implements GithubRepoConfig {
 	path: string;
 	version: string;
 	repo: string;
+	githubHost: string;
 	ref: string;
 	stats: boolean;
 	bundle: string;
@@ -61,6 +62,7 @@ class Config implements GithubRepoConfig {
 		this.path = Const.typingsDir;
 		this.version = Const.configVersion;
 		this.repo = Const.definitelyRepo;
+		this.githubHost = Const.githubHost;
 		this.ref = Const.mainBranch;
 		this.stats = Const.statsDefault;
 		this.otherFields = {};
@@ -147,6 +149,7 @@ class Config implements GithubRepoConfig {
 		var json = this.otherFields;
 		json.version = this.version;
 		json.repo = this.repo;
+		json.githubHost = this.githubHost;
 		json.ref = this.ref;
 		json.path = this.path;
 
@@ -191,6 +194,7 @@ class Config implements GithubRepoConfig {
 		this.path = json.path;
 		this.version = json.version;
 		this.repo = json.repo;
+		this.githubHost = json.githubHost;
 		this.ref = json.ref;
 		this.bundle = json.bundle;
 		this.stats = (typeOf.isBoolean(json.stats) ? json.stats : Const.statsDefault);
@@ -205,9 +209,9 @@ class Config implements GithubRepoConfig {
 			});
 		}
 
-		var reservedFields = ['path', 'version', 'repo', 'ref', 'bundle', 'stats', 'installed'];
-		var otherFieldKeys = Object.keys(json).filter(function(key) { return reservedFields.indexOf(key) === -1; } );
-		this.otherFields = otherFieldKeys.reduce(function(fields, key) {
+		var reservedFields = ['path', 'version', 'repo', 'githubHost', 'ref', 'bundle', 'stats', 'installed'];
+		var otherFieldKeys = Object.keys(json).filter(function (key) { return reservedFields.indexOf(key) === -1; });
+		this.otherFields = otherFieldKeys.reduce(function (fields, key) {
 			fields[key] = json[key];
 			return fields;
 		}, {});

--- a/src/tsd/context/Config.ts
+++ b/src/tsd/context/Config.ts
@@ -149,7 +149,11 @@ class Config implements GithubRepoConfig {
 		var json = this.otherFields;
 		json.version = this.version;
 		json.repo = this.repo;
-		json.githubHost = this.githubHost;
+		if (this.githubHost !== Const.githubHost) {
+			// only write to config if the host is not github.com
+			json.githubHost = this.githubHost;
+		}
+
 		json.ref = this.ref;
 		json.path = this.path;
 
@@ -195,6 +199,10 @@ class Config implements GithubRepoConfig {
 		this.version = json.version;
 		this.repo = json.repo;
 		this.githubHost = json.githubHost;
+		if (!this.githubHost) {
+			// when migrating from file that do not have this parameter make sure upgrade won't fail
+			this.githubHost = Const.githubHost;
+		}
 		this.ref = json.ref;
 		this.bundle = json.bundle;
 		this.stats = (typeOf.isBoolean(json.stats) ? json.stats : Const.statsDefault);

--- a/src/tsd/context/Const.ts
+++ b/src/tsd/context/Const.ts
@@ -14,6 +14,7 @@ var Const = {
 
 	configVersion: 'v4',
 	definitelyRepo: 'borisyankov/DefinitelyTyped',
+	githubHost: 'github.com',
 	mainBranch: 'master',
 	statsDefault: true,
 

--- a/src/tsd/schema/config.ts
+++ b/src/tsd/schema/config.ts
@@ -21,6 +21,11 @@ var schema = Joi.object({
 		.default(Const.definitelyRepo)
 		.required()
 		.description('github repository "owner/name"'),
+	githubHost: Joi
+		.string()
+		.default(Const.githubHost)
+		.optional()
+		.description('github url, used to specify github enteprise url'),
 	ref: Joi
 		.string().regex(/^[\w\.-]+(?:\/[\w\.-]+)*$/)
 		.default(Const.mainBranch)

--- a/test/spec/git/fixtures/config.json
+++ b/test/spec/git/fixtures/config.json
@@ -2,6 +2,7 @@
 	"repo": {
 		"repoOwner": "borisyankov",
 		"repoProject": "DefinitelyTyped",
+		"githubHost": "github.com",
 		"ref": "master"
 	},
 	"data": {


### PR DESCRIPTION
Add an extra parameters in the tsd.json file to support specifying the url to your github host.

Parameter name is githubHost and by default will point to github.com (so no change to current behavior).

If an enterprise github url is specified instead then the url for requests will be adapted to follow the scheme of enterprise github.