### PR TITLE
allow configuring protocol of Github repository url

### DIFF
--- a/src/getContent.ts
+++ b/src/getContent.ts
@@ -76,7 +76,7 @@ function getContent(options): Promise<any> {
 			time: new Date().toISOString()
 		};
 		ret.urls = {
-			def: 'https://' + ret.githubHost + '/' + ret.repo + '/blob/' + ret.ref + '/{path}'
+			def: ret.githubHost + '/' + ret.repo + '/blob/' + ret.ref + '/{path}'
 		};
 		ret.content = content;
 		return ret;

--- a/src/git/GithubURLs.ts
+++ b/src/git/GithubURLs.ts
@@ -17,10 +17,10 @@ class GithubURLs extends URLManager {
 	private _api: string = 'https://api.github.com/repos/{owner}/{project}';
 	private _raw: string = 'https://raw.githubusercontent.com/{owner}/{project}';
 
-	private _enterpriseBase: string = 'https://{githubHost}/{owner}/{project}';
-	private _enterpriseApiBase: string = 'https://{githubHost}/api/v3';
-	private _enterpriseApi: string = 'https://{githubHost}/api/v3/repos/{owner}/{project}';
-	private _enterpriseRaw: string = 'https://{githubHost}/{owner}/{project}/raw';
+	private _enterpriseBase: string = '{+githubHost}/{owner}/{project}';
+	private _enterpriseApiBase: string = '{+githubHost}/api/v3';
+	private _enterpriseApi: string = '{+githubHost}/api/v3/repos/{owner}/{project}';
+	private _enterpriseRaw: string = '{+githubHost}/{owner}/{project}/raw';
 	private _repo: GithubRepo;
 
 	constructor(repo: GithubRepo) {
@@ -32,7 +32,7 @@ class GithubURLs extends URLManager {
 		var raw: string = this._raw;
 		var api: string = this._api;
 		var apiBase: string = this._apiBase;
-		if (this._repo.config.githubHost !== 'github.com') {
+		if (this._repo.config.githubHost !== 'https://github.com') {
 			// We are working with an enterprise github
 			base = this._enterpriseBase;
 			raw = this._enterpriseRaw;

--- a/src/spec/git/GithubURLs.ts
+++ b/src/spec/git/GithubURLs.ts
@@ -40,7 +40,7 @@ describe('GithubRepo / GithubURLs', () => {
 			});
 		});
 		it('should be constructor', () => {
-			repo = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'}, 'baz', gitTest.opts);
+			repo = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'https://github.com'}, 'baz', gitTest.opts);
 			urls = repo.urls;
 			assert.ok(urls, 'instance');
 		});
@@ -56,7 +56,7 @@ describe('GithubRepo / GithubURLs', () => {
 			});
 		});
 		it('should return replaced urls', () => {
-			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'}, 'baz', gitTest.opts).urls;
+			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'https://github.com'}, 'baz', gitTest.opts).urls;
 			var api = 'https://api.github.com/repos/foo/bar';
 			var raw = 'https://raw.githubusercontent.com/foo/bar';
 			var base = 'https://github.com/foo/bar';
@@ -66,7 +66,7 @@ describe('GithubRepo / GithubURLs', () => {
 			assert.strictEqual(urls.rawFile('2ece23298f06d9fb45772fdb1d38086918c80f44', 'sub/folder/file.txt'), rawFile, 'rawFile');
 		});
 		it('should return correctly replaced urls if repoConfig is modified after repo creation', () => {
-			var repoConfig = {repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'};
+			var repoConfig = {repoOwner: 'foo', repoProject: 'bar', githubHost: 'https://github.com'};
 			urls = new GithubRepo(repoConfig, 'baz', gitTest.opts).urls;
 			repoConfig.repoOwner = 'correctOwner';
 			repoConfig.repoProject = 'correctProject';
@@ -77,12 +77,12 @@ describe('GithubRepo / GithubURLs', () => {
 			assert.strictEqual(urls.base(), base, 'base');
 		});
 		it('should return no trailing slash', () => {
-			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.com'}, 'baz', gitTest.opts).urls;
+			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'https://github.com'}, 'baz', gitTest.opts).urls;
 			assert.notMatch(urls.apiBranches(), /\/$/, 'apiBranches');
 			assert.notMatch(urls.apiBranch('abc'), /\/$/, 'apiBranch');
 		});
 		it('should handle enterprise github urls', () => {
-			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'github.mycompany.com'}, 'baz', gitTest.opts).urls;
+			urls = new GithubRepo({repoOwner: 'foo', repoProject: 'bar', githubHost: 'https://github.mycompany.com'}, 'baz', gitTest.opts).urls;
 			var api = 'https://github.mycompany.com/api/v3/repos/foo/bar';
 			var raw = 'https://github.mycompany.com/foo/bar/raw';
 			var base = 'https://github.mycompany.com/foo/bar';

--- a/src/tsd/context/Const.ts
+++ b/src/tsd/context/Const.ts
@@ -14,7 +14,7 @@ var Const = {
 
 	configVersion: 'v4',
 	definitelyRepo: 'borisyankov/DefinitelyTyped',
-	githubHost: 'github.com',
+	githubHost: 'https://github.com',
 	mainBranch: 'master',
 	statsDefault: true,
 

--- a/test/spec/git/fixtures/config.json
+++ b/test/spec/git/fixtures/config.json
@@ -2,7 +2,7 @@
 	"repo": {
 		"repoOwner": "borisyankov",
 		"repoProject": "DefinitelyTyped",
-		"githubHost": "github.com",
+		"githubHost": "https://github.com",
 		"ref": "master"
 	},
 	"data": {


### PR DESCRIPTION
We are using "http" GitHub Enterprise repository for retrieving *.d.ts files.
So I want to configure not only domain but also protocol of the repository.
