### PR TITLE
Automatically adding tsling ignore directive.

### DIFF
--- a/src/tsd/logic/Installer.ts
+++ b/src/tsd/logic/Installer.ts
@@ -119,7 +119,7 @@ class Installer extends CoreModule {
 			}
 			// write
 			return this.core.content.loadContent(file).then((blob) => {
-				return fileIO.write(targetPath, blob.content);
+				return fileIO.write(targetPath, "/* tslint:disable */\n" + blob.content);
 			}).return(targetPath);
 		});
 	}


### PR DESCRIPTION
It's currently very hard to use **tsd** and **tslint** together, especially in automated builds with **Gulp** etc. as `tslint` lacks option to ignore certain files.

As implementing ignore option in **tslint** seems to stuck (palantir/tslint#73) I thought that maybe it could be handled on **tsd** side by automatically adding ignore header so the file is not linted.