### PR TITLE
Correct the signature of setHeader

### DIFF
--- a/typings/node/node.d.ts
+++ b/typings/node/node.d.ts
@@ -302,7 +302,7 @@ declare module "http" {
         writeHead(statusCode: number, reasonPhrase?: string, headers?: any): void;
         writeHead(statusCode: number, headers?: any): void;
         statusCode: number;
-        setHeader(name: string, value: string): void;
+        setHeader(name: string, value: any /* string | string[] */): void;
         sendDate: boolean;
         getHeader(name: string): string;
         removeHeader(name: string): void;


### PR DESCRIPTION
setHeader() takes either a string or a string array as it's second argument.

This uses "any" instead consistent with other union types in this file. 

See https://nodejs.org/api/http.html#http_response_setheader_name_value